### PR TITLE
set_res & get_res implemented in conjugategradient.c -.h and main.c

### DIFF
--- a/include/conjugategradient.h
+++ b/include/conjugategradient.h
@@ -2,5 +2,5 @@
 
 // test
 void conj_grad ( double complex b[], double complex x[], void(*pfunc)(double complex *, double complex*));
-void set_residue(double res);
-double get_residue();
+void set_res(char *argv[]);
+double get_res();

--- a/main.c
+++ b/main.c
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
   int N = get_N();
   print_N();
   double m = atof(argv[2]);
-  set_residue(atof(argv[5]));
+  set_res(argv);
   set_kinetic_params(m);
   set_potential(atoi(argv[3]));
   print_hamiltonian_info();

--- a/modules/conjugategradient.c
+++ b/modules/conjugategradient.c
@@ -6,7 +6,7 @@
 
 
 
-
+static double accuracy=0;
 
 double complex dot_product(double complex a[], double complex b[], int length)
 {
@@ -19,11 +19,26 @@ double complex dot_product(double complex a[], double complex b[], int length)
 
 }
 
+/*******************************************************************************
+set_res initialzes the residue value by assigning the 5th input parameter to res
+*******************************************************************************/
+void set_res(char *argv[]) {
+  double val = 0;
+  val = atof(argv[5]);
+  if (val > 0) { accuracy = val; }
+  else {
+    printf("[conjugategradient | set_residue()] ERROR: residue has to be > 0!");
+    exit(-1);
+  }
+}
 
-
-
-
-
+double get_res() {
+  if (accuracy == 0) {
+    printf("[conjugategradient | set_res()] ERROR: Residue not initialzed yet!");
+    exit(-1);
+  }
+  return accuracy; 
+}
 
 
 void conj_grad ( double complex b[], double complex x[], void(*pfunc)(double complex *, double complex*))    // § need to change the parameters of pfunc depending on which pfunc
@@ -41,7 +56,7 @@ void conj_grad ( double complex b[], double complex x[], void(*pfunc)(double com
     double complex p[N];
     double complex Ap[N];
     double complex Ax[N] ;
-    double accuracy = 1.e-3;
+/*    double accuracy = 1.e-3; */
 
     double complex dot_product(double complex a[], double complex b[], int length);
 
@@ -167,11 +182,5 @@ void conj_grad ( double complex b[], double complex x[], void(*pfunc)(double com
 
     }
 
-
-
     return;
-
-
-
-
 }

--- a/modules/geometry.c
+++ b/modules/geometry.c
@@ -27,7 +27,7 @@ void set_params(int argc, char *argv[]){
   val = atoi(argv[1]);
   if (argc < 2) {
     printf("[ geometry.c| set_params ] ERROR! You forgot your NUM, A and EPS parameters.\n"
-  "Remeber: executable [NUM] [Lattice Spacing] [Tolerance]!\n");
+    "Remeber: executable [NUM] [Lattice Spacing] [Tolerance]!\n");
     exit(-1);
   }
 


### PR DESCRIPTION
Included set_res and get_res into conjugategradient.c and .h. Therefore in main.c the way to set res was changed to: set_res(argv).